### PR TITLE
Add Category CRUD

### DIFF
--- a/src/main/java/com/ctottene/app/controller/CategoryController.java
+++ b/src/main/java/com/ctottene/app/controller/CategoryController.java
@@ -1,0 +1,61 @@
+package com.ctottene.app.controller;
+
+import com.ctottene.application.usecase.DeleteCategoryUseCase;
+import com.ctottene.application.usecase.ListCategoryUseCase;
+import com.ctottene.application.usecase.RegisterCategoryUseCase;
+import com.ctottene.application.usecase.UpdateCategoryUseCase;
+import com.ctottene.application.usecase.dto.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+
+    private final RegisterCategoryUseCase registerUseCase;
+    private final ListCategoryUseCase listUseCase;
+    private final UpdateCategoryUseCase updateUseCase;
+    private final DeleteCategoryUseCase deleteUseCase;
+
+    public CategoryController(
+            RegisterCategoryUseCase registerUseCase,
+            ListCategoryUseCase listUseCase,
+            UpdateCategoryUseCase updateUseCase,
+            DeleteCategoryUseCase deleteUseCase
+    ) {
+        this.registerUseCase = registerUseCase;
+        this.listUseCase = listUseCase;
+        this.updateUseCase = updateUseCase;
+        this.deleteUseCase = deleteUseCase;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ResponseEntity<RegisterCategoryOutput> register(@RequestBody RegisterCategoryInput input) {
+        RegisterCategoryOutput output = registerUseCase.execute(input);
+        return ResponseEntity.ok(output);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoryOutput>> list() {
+        return ResponseEntity.ok(listUseCase.execute());
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable UUID id, @RequestBody UpdateCategoryInput input) {
+        updateUseCase.execute(new UpdateCategoryInput(id, input.name(), input.description()));
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        deleteUseCase.execute(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ctottene/application/usecase/DeleteCategoryUseCase.java
+++ b/src/main/java/com/ctottene/application/usecase/DeleteCategoryUseCase.java
@@ -1,0 +1,6 @@
+package com.ctottene.application.usecase;
+
+import java.util.UUID;
+
+public interface DeleteCategoryUseCase extends UseCaseInputOnly<UUID> {
+}

--- a/src/main/java/com/ctottene/application/usecase/ListCategoryUseCase.java
+++ b/src/main/java/com/ctottene/application/usecase/ListCategoryUseCase.java
@@ -1,0 +1,8 @@
+package com.ctottene.application.usecase;
+
+import com.ctottene.application.usecase.dto.CategoryOutput;
+
+import java.util.List;
+
+public interface ListCategoryUseCase extends UseCaseOutputOnly<List<CategoryOutput>> {
+}

--- a/src/main/java/com/ctottene/application/usecase/RegisterCategoryUseCase.java
+++ b/src/main/java/com/ctottene/application/usecase/RegisterCategoryUseCase.java
@@ -1,0 +1,7 @@
+package com.ctottene.application.usecase;
+
+import com.ctottene.application.usecase.dto.RegisterCategoryInput;
+import com.ctottene.application.usecase.dto.RegisterCategoryOutput;
+
+public interface RegisterCategoryUseCase extends UseCase<RegisterCategoryInput, RegisterCategoryOutput> {
+}

--- a/src/main/java/com/ctottene/application/usecase/UpdateCategoryUseCase.java
+++ b/src/main/java/com/ctottene/application/usecase/UpdateCategoryUseCase.java
@@ -1,0 +1,6 @@
+package com.ctottene.application.usecase;
+
+import com.ctottene.application.usecase.dto.UpdateCategoryInput;
+
+public interface UpdateCategoryUseCase extends UseCase<UpdateCategoryInput, Void> {
+}

--- a/src/main/java/com/ctottene/application/usecase/dto/CategoryOutput.java
+++ b/src/main/java/com/ctottene/application/usecase/dto/CategoryOutput.java
@@ -1,0 +1,5 @@
+package com.ctottene.application.usecase.dto;
+
+import java.util.UUID;
+
+public record CategoryOutput(UUID id, String name, String description) {}

--- a/src/main/java/com/ctottene/application/usecase/dto/RegisterCategoryInput.java
+++ b/src/main/java/com/ctottene/application/usecase/dto/RegisterCategoryInput.java
@@ -1,0 +1,3 @@
+package com.ctottene.application.usecase.dto;
+
+public record RegisterCategoryInput(String name, String description) {}

--- a/src/main/java/com/ctottene/application/usecase/dto/RegisterCategoryOutput.java
+++ b/src/main/java/com/ctottene/application/usecase/dto/RegisterCategoryOutput.java
@@ -1,0 +1,5 @@
+package com.ctottene.application.usecase.dto;
+
+import java.util.UUID;
+
+public record RegisterCategoryOutput(UUID id) {}

--- a/src/main/java/com/ctottene/application/usecase/dto/UpdateCategoryInput.java
+++ b/src/main/java/com/ctottene/application/usecase/dto/UpdateCategoryInput.java
@@ -1,0 +1,5 @@
+package com.ctottene.application.usecase.dto;
+
+import java.util.UUID;
+
+public record UpdateCategoryInput(UUID id, String name, String description) {}

--- a/src/main/java/com/ctottene/application/usecase/impl/DeleteCategoryUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/impl/DeleteCategoryUseCaseImpl.java
@@ -1,0 +1,22 @@
+package com.ctottene.application.usecase.impl;
+
+import com.ctottene.application.usecase.DeleteCategoryUseCase;
+import com.ctottene.domain.gateway.CategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class DeleteCategoryUseCaseImpl implements DeleteCategoryUseCase {
+
+    private final CategoryRepository repository;
+
+    public DeleteCategoryUseCaseImpl(CategoryRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void execute(UUID input) {
+        repository.deleteById(input);
+    }
+}

--- a/src/main/java/com/ctottene/application/usecase/impl/ListCategoryUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/impl/ListCategoryUseCaseImpl.java
@@ -1,0 +1,30 @@
+package com.ctottene.application.usecase.impl;
+
+import com.ctottene.application.usecase.ListCategoryUseCase;
+import com.ctottene.application.usecase.dto.CategoryOutput;
+import com.ctottene.domain.gateway.CategoryRepository;
+import com.ctottene.infrastructure.security.AuthenticatedUser;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ListCategoryUseCaseImpl implements ListCategoryUseCase {
+
+    private final CategoryRepository repository;
+    private final AuthenticatedUser authenticatedUser;
+
+    public ListCategoryUseCaseImpl(CategoryRepository repository, AuthenticatedUser authenticatedUser) {
+        this.repository = repository;
+        this.authenticatedUser = authenticatedUser;
+    }
+
+    @Override
+    public List<CategoryOutput> execute() {
+        return repository.findAllByTenantId(authenticatedUser.getTenantId())
+                .stream()
+                .map(c -> new CategoryOutput(c.getId(), c.getName(), c.getDescription()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ctottene/application/usecase/impl/RegisterCategoryUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/impl/RegisterCategoryUseCaseImpl.java
@@ -1,0 +1,47 @@
+package com.ctottene.application.usecase.impl;
+
+import com.ctottene.application.usecase.RegisterCategoryUseCase;
+import com.ctottene.application.usecase.dto.RegisterCategoryInput;
+import com.ctottene.application.usecase.dto.RegisterCategoryOutput;
+import com.ctottene.domain.gateway.CategoryRepository;
+import com.ctottene.domain.model.Category;
+import com.ctottene.infrastructure.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class RegisterCategoryUseCaseImpl implements RegisterCategoryUseCase {
+
+    private final Logger log = LoggerFactory.getLogger(RegisterCategoryUseCaseImpl.class);
+
+    private final CategoryRepository repository;
+    private final AuthenticatedUser authenticatedUser;
+
+    public RegisterCategoryUseCaseImpl(CategoryRepository repository, AuthenticatedUser authenticatedUser) {
+        this.repository = repository;
+        this.authenticatedUser = authenticatedUser;
+    }
+
+    @Override
+    public RegisterCategoryOutput execute(RegisterCategoryInput input) {
+        Category category = new Category();
+        category.setId(UUID.randomUUID());
+        category.setName(input.name());
+        category.setDescription(input.description());
+        category.setCreatedAt(Instant.now());
+        category.setUpdatedAt(Instant.now());
+        category.setCreatedBy(authenticatedUser.getId());
+        category.setTenantId(authenticatedUser.getTenantId());
+        category.setUserTimeZone(authenticatedUser.getTimezone());
+
+        log.info("Saving Category: {}", category.getName());
+        Category saved = repository.save(category);
+        log.info("Saved category {}", saved.getId());
+
+        return new RegisterCategoryOutput(saved.getId());
+    }
+}

--- a/src/main/java/com/ctottene/application/usecase/impl/UpdateCategoryUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/impl/UpdateCategoryUseCaseImpl.java
@@ -1,0 +1,41 @@
+package com.ctottene.application.usecase.impl;
+
+import com.ctottene.application.usecase.UpdateCategoryUseCase;
+import com.ctottene.application.usecase.dto.UpdateCategoryInput;
+import com.ctottene.domain.gateway.CategoryRepository;
+import com.ctottene.domain.model.Category;
+import com.ctottene.infrastructure.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class UpdateCategoryUseCaseImpl implements UpdateCategoryUseCase {
+
+    private final Logger log = LoggerFactory.getLogger(UpdateCategoryUseCaseImpl.class);
+
+    private final CategoryRepository repository;
+    private final AuthenticatedUser authenticatedUser;
+
+    public UpdateCategoryUseCaseImpl(CategoryRepository repository, AuthenticatedUser authenticatedUser) {
+        this.repository = repository;
+        this.authenticatedUser = authenticatedUser;
+    }
+
+    @Override
+    public Void execute(UpdateCategoryInput input) {
+        Category category = repository.findById(input.id())
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+
+        category.setName(input.name());
+        category.setDescription(input.description());
+        category.setUpdatedAt(Instant.now());
+        category.setUpdatedBy(authenticatedUser.getId());
+
+        log.info("Updating category {}", category.getId());
+        repository.save(category);
+        return null;
+    }
+}

--- a/src/main/java/com/ctottene/domain/gateway/CategoryRepository.java
+++ b/src/main/java/com/ctottene/domain/gateway/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.ctottene.domain.gateway;
+
+import com.ctottene.domain.model.Category;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CategoryRepository {
+    Optional<Category> findById(UUID id);
+    List<Category> findAllByTenantId(UUID tenantId);
+    Category save(Category category);
+    void deleteById(UUID id);
+}

--- a/src/main/java/com/ctottene/domain/model/Category.java
+++ b/src/main/java/com/ctottene/domain/model/Category.java
@@ -1,0 +1,37 @@
+package com.ctottene.domain.model;
+
+import java.util.UUID;
+
+/**
+ * Category entity used to group transactions.
+ */
+
+public class Category extends AuditMetadata {
+    private UUID id;
+    private String name;
+    private String description;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/ctottene/infrastructure/persistence/JpaCategoryEntityRepository.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/JpaCategoryEntityRepository.java
@@ -1,0 +1,11 @@
+package com.ctottene.infrastructure.persistence;
+
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaCategoryEntityRepository extends JpaRepository<CategoryEntity, UUID> {
+    List<CategoryEntity> findAllByTenantId(UUID tenantId);
+}

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
@@ -1,0 +1,77 @@
+package com.ctottene.infrastructure.persistence.entity;
+
+import com.ctottene.domain.model.Category;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "categories")
+public class CategoryEntity extends com.ctottene.infrastructure.persistence.common.AuditMetadataEntity {
+
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    public CategoryEntity() {}
+
+    public static CategoryEntity fromModel(Category category) {
+        CategoryEntity entity = new CategoryEntity();
+        entity.id = category.getId();
+        entity.name = category.getName();
+        entity.description = category.getDescription();
+        entity.setCreatedAt(category.getCreatedAt());
+        entity.setCreatedBy(category.getCreatedBy());
+        entity.setUpdatedAt(category.getUpdatedAt());
+        entity.setUpdatedBy(category.getUpdatedBy());
+        entity.setTenantId(category.getTenantId());
+        entity.setUserTimeZone(category.getUserTimeZone());
+        return entity;
+    }
+
+    public Category toModel() {
+        Category category = new Category();
+        category.setId(id);
+        category.setName(name);
+        category.setDescription(description);
+        category.setCreatedAt(getCreatedAt());
+        category.setCreatedBy(getCreatedBy());
+        category.setUpdatedAt(getUpdatedAt());
+        category.setUpdatedBy(getUpdatedBy());
+        category.setTenantId(getTenantId());
+        category.setUserTimeZone(getUserTimeZone());
+        return category;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/ctottene/infrastructure/persistence/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/repository/CategoryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.ctottene.infrastructure.persistence.repository;
+
+import com.ctottene.domain.gateway.CategoryRepository;
+import com.ctottene.domain.model.Category;
+import com.ctottene.infrastructure.persistence.JpaCategoryEntityRepository;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Repository
+public class CategoryRepositoryImpl implements CategoryRepository {
+
+    private final JpaCategoryEntityRepository jpaRepository;
+
+    public CategoryRepositoryImpl(JpaCategoryEntityRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<Category> findById(UUID id) {
+        return jpaRepository.findById(id).map(CategoryEntity::toModel);
+    }
+
+    @Override
+    public List<Category> findAllByTenantId(UUID tenantId) {
+        return jpaRepository.findAllByTenantId(tenantId).stream()
+                .map(CategoryEntity::toModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Category save(Category category) {
+        CategoryEntity entity = CategoryEntity.fromModel(category);
+        CategoryEntity saved = jpaRepository.save(entity);
+        return saved.toModel();
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/db/migration/V5__create_categories_table.sql
+++ b/src/main/resources/db/migration/V5__create_categories_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE categories (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    tenant_id UUID NOT NULL,
+    user_time_zone VARCHAR(50) NOT NULL DEFAULT 'UTC',
+    created_at TIMESTAMP NOT NULL,
+    created_by UUID NOT NULL,
+    updated_at TIMESTAMP,
+    updated_by UUID
+);


### PR DESCRIPTION
## Summary
- add Category domain model and repository contract
- implement persistence entity and repository for Category
- create CRUD use cases and controller
- add Flyway migration for categories table

## Testing
- `./gradlew test --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687dc0ca90b4832aaa17cfab3d2ea5dd