### PR TITLE
Implement Income-Category relation

### DIFF
--- a/src/main/java/com/ctottene/application/usecase/dto/RegisterIncomeInput.java
+++ b/src/main/java/com/ctottene/application/usecase/dto/RegisterIncomeInput.java
@@ -7,5 +7,6 @@ public record RegisterIncomeInput(
         String description,
         BigDecimal amount,
         Instant originalDate,
-        Instant dueDate
+        Instant dueDate,
+        java.util.UUID categoryId
 ) {}

--- a/src/main/java/com/ctottene/application/usecase/impl/RegisterIncomeUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/impl/RegisterIncomeUseCaseImpl.java
@@ -5,6 +5,7 @@ import com.ctottene.application.usecase.dto.RegisterIncomeInput;
 import com.ctottene.application.usecase.dto.RegisterIncomeOutput;
 import com.ctottene.domain.gateway.IncomeRepository;
 import com.ctottene.domain.model.Income;
+import com.ctottene.domain.model.Category;
 import com.ctottene.infrastructure.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,11 @@ public class RegisterIncomeUseCaseImpl implements RegisterIncomeUseCase {
         income.setAmount(input.amount());
         income.setOriginalDate(input.originalDate());
         income.setDueDate(input.dueDate());
+        if (input.categoryId() != null) {
+            Category category = new Category();
+            category.setId(input.categoryId());
+            income.setCategory(category);
+        }
         income.setUserTimeZone(authenticatedUser.getTimezone());
 
         income.setCreatedAt(Instant.now());

--- a/src/main/java/com/ctottene/domain/model/Category.java
+++ b/src/main/java/com/ctottene/domain/model/Category.java
@@ -1,5 +1,6 @@
 package com.ctottene.domain.model;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -10,6 +11,7 @@ public class Category extends AuditMetadata {
     private UUID id;
     private String name;
     private String description;
+    private List<Income> incomes;
 
     public UUID getId() {
         return id;
@@ -33,5 +35,13 @@ public class Category extends AuditMetadata {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public List<Income> getIncomes() {
+        return incomes;
+    }
+
+    public void setIncomes(List<Income> incomes) {
+        this.incomes = incomes;
     }
 }

--- a/src/main/java/com/ctottene/domain/model/Income.java
+++ b/src/main/java/com/ctottene/domain/model/Income.java
@@ -1,10 +1,16 @@
 package com.ctottene.domain.model;
 
 import com.ctottene.domain.enums.TransactionType;
+import com.ctottene.domain.model.Category;
+
+/**
+ * Represents an income transaction. Each income belongs to a {@link Category}.
+ */
 
 public class Income extends Transaction {
 
     private TransactionType type = TransactionType.INCOME;
+    private Category category;
 
     public TransactionType getType() {
         return type;
@@ -12,5 +18,13 @@ public class Income extends Transaction {
 
     public void setType(TransactionType type) {
         this.type = type;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.FetchType;
+import com.ctottene.infrastructure.persistence.entity.IncomeEntity;
 
 import java.util.UUID;
 
@@ -20,6 +23,9 @@ public class CategoryEntity extends com.ctottene.infrastructure.persistence.comm
     private String name;
 
     private String description;
+
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
+    private java.util.List<IncomeEntity> incomes;
 
     public CategoryEntity() {}
 
@@ -48,6 +54,13 @@ public class CategoryEntity extends com.ctottene.infrastructure.persistence.comm
         category.setUpdatedBy(getUpdatedBy());
         category.setTenantId(getTenantId());
         category.setUserTimeZone(getUserTimeZone());
+        if (incomes != null) {
+            java.util.List<com.ctottene.domain.model.Income> list = new java.util.ArrayList<>();
+            for (IncomeEntity incomeEntity : incomes) {
+                list.add(incomeEntity.toModel());
+            }
+            category.setIncomes(list);
+        }
         return category;
     }
 
@@ -73,5 +86,13 @@ public class CategoryEntity extends com.ctottene.infrastructure.persistence.comm
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public java.util.List<IncomeEntity> getIncomes() {
+        return incomes;
+    }
+
+    public void setIncomes(java.util.List<IncomeEntity> incomes) {
+        this.incomes = incomes;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/IncomeEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/IncomeEntity.java
@@ -1,12 +1,22 @@
 package com.ctottene.infrastructure.persistence.entity;
 
 import com.ctottene.domain.model.Income;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+
+import java.util.UUID;
 
 @Entity
 @Table(name = "incomes")
 public class IncomeEntity extends TransactionEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryEntity category;
 
     public IncomeEntity() {}
 
@@ -26,6 +36,12 @@ public class IncomeEntity extends TransactionEntity {
         entity.setTenantId(income.getTenantId());
         entity.setUserTimeZone(income.getUserTimeZone());
 
+        if (income.getCategory() != null) {
+            CategoryEntity cat = new CategoryEntity();
+            cat.setId(income.getCategory().getId());
+            entity.setCategory(cat);
+        }
+
         return entity;
     }
 
@@ -44,6 +60,18 @@ public class IncomeEntity extends TransactionEntity {
         income.setUpdatedBy(getUpdatedBy());
         income.setTenantId(getTenantId());
 
+        if (category != null) {
+            income.setCategory(category.toModel());
+        }
+
         return income;
+    }
+
+    public CategoryEntity getCategory() {
+        return category;
+    }
+
+    public void setCategory(CategoryEntity category) {
+        this.category = category;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/repository/IncomeRepositoryImpl.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/repository/IncomeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ctottene.domain.gateway.IncomeRepository;
 import com.ctottene.domain.model.Income;
 import com.ctottene.infrastructure.persistence.JpaIncomeEntityRepository;
 import com.ctottene.infrastructure.persistence.entity.IncomeEntity;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -56,6 +57,11 @@ public class IncomeRepositoryImpl implements IncomeRepository {
         entity.setCreatedBy(income.getCreatedBy());
         entity.setTenantId(income.getTenantId());
         entity.setUserTimeZone(income.getUserTimeZone());
+        if (income.getCategory() != null) {
+            CategoryEntity cat = new CategoryEntity();
+            cat.setId(income.getCategory().getId());
+            entity.setCategory(cat);
+        }
         return entity;
     }
 }

--- a/src/main/resources/db/migration/V6__add_category_relation.sql
+++ b/src/main/resources/db/migration/V6__add_category_relation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE incomes ADD COLUMN category_id UUID NOT NULL;
+ALTER TABLE incomes ADD CONSTRAINT fk_income_category FOREIGN KEY (category_id) REFERENCES categories(id);


### PR DESCRIPTION
## Summary
- link income entries to a category
- allow categories to expose their incomes
- persist the relation via JPA entities
- accept `categoryId` when registering an income
- add flyway migration for new column

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687dc96c19f8832a8ed1838e925077e4