### PR TITLE
Add category relation to expenses

### DIFF
--- a/src/main/java/com/ctottene/application/usecase/expense/dto/RegisterExpenseInput.java
+++ b/src/main/java/com/ctottene/application/usecase/expense/dto/RegisterExpenseInput.java
@@ -7,5 +7,6 @@ public record RegisterExpenseInput(
         String description,
         BigDecimal amount,
         Instant originalDate,
-        Instant dueDate
+        Instant dueDate,
+        java.util.UUID categoryId
 ) {}

--- a/src/main/java/com/ctottene/application/usecase/expense/impl/RegisterExpenseUseCaseImpl.java
+++ b/src/main/java/com/ctottene/application/usecase/expense/impl/RegisterExpenseUseCaseImpl.java
@@ -5,6 +5,7 @@ import com.ctottene.application.usecase.expense.dto.RegisterExpenseInput;
 import com.ctottene.application.usecase.expense.dto.RegisterExpenseOutput;
 import com.ctottene.domain.gateway.ExpenseRepository;
 import com.ctottene.domain.model.Expense;
+import com.ctottene.domain.model.Category;
 import com.ctottene.infrastructure.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,24 +33,29 @@ public class RegisterExpenseUseCaseImpl implements RegisterExpenseUseCase {
     @Override
     public RegisterExpenseOutput execute(RegisterExpenseInput input) {
 
-        Expense income = new Expense();
-        income.setId(UUID.randomUUID());
-        income.setDescription(input.description());
-        income.setAmount(input.amount());
-        income.setOriginalDate(input.originalDate());
-        income.setDueDate(input.dueDate());
-        income.setUserTimeZone(authenticatedUser.getTimezone());
+        Expense expense = new Expense();
+        expense.setId(UUID.randomUUID());
+        expense.setDescription(input.description());
+        expense.setAmount(input.amount());
+        expense.setOriginalDate(input.originalDate());
+        expense.setDueDate(input.dueDate());
+        if (input.categoryId() != null) {
+            Category category = new Category();
+            category.setId(input.categoryId());
+            expense.setCategory(category);
+        }
+        expense.setUserTimeZone(authenticatedUser.getTimezone());
 
-        income.setCreatedAt(Instant.now());
-        income.setUpdatedAt(Instant.now());
-        income.setCreatedBy(authenticatedUser.getId());
-        income.setTenantId(authenticatedUser.getTenantId());
-        income.setUserTimeZone(authenticatedUser.getTimezone());
+        expense.setCreatedAt(Instant.now());
+        expense.setUpdatedAt(Instant.now());
+        expense.setCreatedBy(authenticatedUser.getId());
+        expense.setTenantId(authenticatedUser.getTenantId());
+        expense.setUserTimeZone(authenticatedUser.getTimezone());
 
-        log.info("Saving Expense: {}", income);
-        Expense saved = expenseRepository.save(income);
+        log.info("Saving Expense: {}", expense);
+        Expense saved = expenseRepository.save(expense);
         log.info("Saved successfully: {}", saved.getId());
 
-        return new RegisterExpenseOutput(income.getId());
+        return new RegisterExpenseOutput(expense.getId());
     }
 }

--- a/src/main/java/com/ctottene/domain/model/Category.java
+++ b/src/main/java/com/ctottene/domain/model/Category.java
@@ -8,6 +8,7 @@ public class Category extends AuditMetadata {
     private String name;
     private String description;
     private List<Income> incomes;
+    private List<Expense> expenses;
 
     public UUID getId() {
         return id;
@@ -39,5 +40,13 @@ public class Category extends AuditMetadata {
 
     public void setIncomes(List<Income> incomes) {
         this.incomes = incomes;
+    }
+
+    public List<Expense> getExpenses() {
+        return expenses;
+    }
+
+    public void setExpenses(List<Expense> expenses) {
+        this.expenses = expenses;
     }
 }

--- a/src/main/java/com/ctottene/domain/model/Income.java
+++ b/src/main/java/com/ctottene/domain/model/Income.java
@@ -1,7 +1,6 @@
 package com.ctottene.domain.model;
 
 import com.ctottene.domain.enums.TransactionType;
-import com.ctottene.domain.model.Category;
 
 /**
  * Represents an income transaction. Each income belongs to a {@link Category}.
@@ -10,7 +9,6 @@ import com.ctottene.domain.model.Category;
 public class Income extends Transaction {
 
     private TransactionType type = TransactionType.INCOME;
-    private Category category;
 
     public TransactionType getType() {
         return type;
@@ -20,11 +18,4 @@ public class Income extends Transaction {
         this.type = type;
     }
 
-    public Category getCategory() {
-        return category;
-    }
-
-    public void setCategory(Category category) {
-        this.category = category;
-    }
 }

--- a/src/main/java/com/ctottene/domain/model/Transaction.java
+++ b/src/main/java/com/ctottene/domain/model/Transaction.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
+
 public abstract class Transaction extends AuditMetadata {
     protected UUID id;
     protected String description;
@@ -13,6 +14,8 @@ public abstract class Transaction extends AuditMetadata {
     protected Instant originalDate;
     protected Instant dueDate;
     protected Instant paidAt;
+
+    protected Category category;
 
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
@@ -34,4 +37,7 @@ public abstract class Transaction extends AuditMetadata {
 
     public Instant getPaidAt() { return paidAt; }
     public void setPaidAt(Instant paidAt) { this.paidAt = paidAt; }
+
+    public Category getCategory() { return category; }
+    public void setCategory(Category category) { this.category = category; }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/CategoryEntity.java
@@ -2,7 +2,9 @@ package com.ctottene.infrastructure.persistence.entity;
 
 import com.ctottene.domain.model.Category;
 import com.ctottene.domain.model.Income;
+import com.ctottene.domain.model.Expense;
 import com.ctottene.infrastructure.persistence.common.AuditMetadataEntity;
+import com.ctottene.infrastructure.persistence.entity.ExpenseEntity;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
@@ -24,6 +26,9 @@ public class CategoryEntity extends AuditMetadataEntity {
 
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
     private java.util.List<IncomeEntity> incomes;
+
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
+    private java.util.List<ExpenseEntity> expenses;
 
     public CategoryEntity() {}
 
@@ -59,6 +64,13 @@ public class CategoryEntity extends AuditMetadataEntity {
             }
             category.setIncomes(list);
         }
+        if (expenses != null) {
+            List<Expense> expList = new ArrayList<>();
+            for (ExpenseEntity expenseEntity : expenses) {
+                expList.add(expenseEntity.toModel());
+            }
+            category.setExpenses(expList);
+        }
         return category;
     }
 
@@ -92,5 +104,13 @@ public class CategoryEntity extends AuditMetadataEntity {
 
     public void setIncomes(java.util.List<IncomeEntity> incomes) {
         this.incomes = incomes;
+    }
+
+    public java.util.List<ExpenseEntity> getExpenses() {
+        return expenses;
+    }
+
+    public void setExpenses(java.util.List<ExpenseEntity> expenses) {
+        this.expenses = expenses;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/ExpenseEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/ExpenseEntity.java
@@ -3,6 +3,7 @@ package com.ctottene.infrastructure.persistence.entity;
 import com.ctottene.domain.model.Expense;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 
 @Entity
 @Table(name = "expenses")
@@ -24,6 +25,13 @@ public class ExpenseEntity extends TransactionEntity {
         entity.setUpdatedAt(expense.getUpdatedAt());
         entity.setUpdatedBy(expense.getUpdatedBy());
         entity.setTenantId(expense.getTenantId());
+        entity.setUserTimeZone(expense.getUserTimeZone());
+
+        if (expense.getCategory() != null) {
+            CategoryEntity cat = new CategoryEntity();
+            cat.setId(expense.getCategory().getId());
+            entity.setCategory(cat);
+        }
 
         return entity;
     }
@@ -42,6 +50,10 @@ public class ExpenseEntity extends TransactionEntity {
         expense.setUpdatedAt(getUpdatedAt());
         expense.setUpdatedBy(getUpdatedBy());
         expense.setTenantId(getTenantId());
+
+        if (getCategory() != null) {
+            expense.setCategory(getCategory().toModel());
+        }
 
         return expense;
     }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/IncomeEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/IncomeEntity.java
@@ -4,9 +4,6 @@ import com.ctottene.domain.model.Income;
 import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.FetchType;
 
 import java.util.UUID;
 
@@ -14,9 +11,6 @@ import java.util.UUID;
 @Table(name = "incomes")
 public class IncomeEntity extends TransactionEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
-    private CategoryEntity category;
 
     public IncomeEntity() {}
 
@@ -60,18 +54,9 @@ public class IncomeEntity extends TransactionEntity {
         income.setUpdatedBy(getUpdatedBy());
         income.setTenantId(getTenantId());
 
-        if (category != null) {
-            income.setCategory(category.toModel());
+        if (getCategory() != null) {
+            income.setCategory(getCategory().toModel());
         }
-
         return income;
-    }
-
-    public CategoryEntity getCategory() {
-        return category;
-    }
-
-    public void setCategory(CategoryEntity category) {
-        this.category = category;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/entity/TransactionEntity.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/entity/TransactionEntity.java
@@ -1,9 +1,13 @@
 package com.ctottene.infrastructure.persistence.entity;
 
 import com.ctottene.infrastructure.persistence.common.AuditMetadataEntity;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -30,6 +34,10 @@ public abstract class TransactionEntity extends AuditMetadataEntity {
 
     @Column(name = "paid_at")
     private Instant paidAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryEntity category;
 
     public UUID getId() {
         return id;
@@ -77,5 +85,13 @@ public abstract class TransactionEntity extends AuditMetadataEntity {
 
     public void setPaidAt(Instant paidAt) {
         this.paidAt = paidAt;
+    }
+
+    public CategoryEntity getCategory() {
+        return category;
+    }
+
+    public void setCategory(CategoryEntity category) {
+        this.category = category;
     }
 }

--- a/src/main/java/com/ctottene/infrastructure/persistence/repository/ExpenseRepositoryImpl.java
+++ b/src/main/java/com/ctottene/infrastructure/persistence/repository/ExpenseRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ctottene.domain.gateway.ExpenseRepository;
 import com.ctottene.domain.model.Expense;
 import com.ctottene.infrastructure.persistence.JpaExpenseEntityRepository;
 import com.ctottene.infrastructure.persistence.entity.ExpenseEntity;
+import com.ctottene.infrastructure.persistence.entity.CategoryEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -56,6 +57,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepository {
         entity.setCreatedBy(expense.getCreatedBy());
         entity.setTenantId(expense.getTenantId());
         entity.setUserTimeZone(expense.getUserTimeZone());
+        if (expense.getCategory() != null) {
+            CategoryEntity cat = new CategoryEntity();
+            cat.setId(expense.getCategory().getId());
+            entity.setCategory(cat);
+        }
         return entity;
     }
 }

--- a/src/main/resources/db/migration/V7__add_expense_category_relation.sql
+++ b/src/main/resources/db/migration/V7__add_expense_category_relation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expenses ADD COLUMN category_id UUID NOT NULL;
+ALTER TABLE expenses ADD CONSTRAINT fk_expense_category FOREIGN KEY (category_id) REFERENCES categories(id);


### PR DESCRIPTION
## Summary
- support categorizing expenses like incomes
- unify Transaction model to hold category
- map expense entities with categories
- update DTOs/usecases for expense category
- create database migration for expense category

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687dd21c7604832aba0771b3a1bd37f4