### PR TITLE
Revert migrations for transactions

### DIFF
--- a/src/main/resources/db/migration/V8__add_transaction_extra_fields.sql
+++ b/src/main/resources/db/migration/V8__add_transaction_extra_fields.sql
@@ -1,0 +1,10 @@
+ALTER TABLE incomes ADD COLUMN original_amount NUMERIC(19, 2);
+ALTER TABLE incomes ADD COLUMN interest NUMERIC(19, 2);
+ALTER TABLE incomes ADD COLUMN fine NUMERIC(19, 2);
+ALTER TABLE incomes ADD COLUMN discount NUMERIC(19, 2);
+
+ALTER TABLE expenses ADD COLUMN original_amount NUMERIC(19, 2);
+ALTER TABLE expenses ADD COLUMN interest NUMERIC(19, 2);
+ALTER TABLE expenses ADD COLUMN fine NUMERIC(19, 2);
+ALTER TABLE expenses ADD COLUMN discount NUMERIC(19, 2);
+


### PR DESCRIPTION
## Summary
- ensure incomes and expenses create scripts exclude extra fields
- add migration V8 that adds `original_amount`, `interest`, `fine`, and `discount`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f8da944f0832a8d390a1490215ec4